### PR TITLE
Update API to accept clickable icon as argument

### DIFF
--- a/dist/material-design-hamburger.js
+++ b/dist/material-design-hamburger.js
@@ -2,12 +2,10 @@
 
   module.exports = materialDesignHamburger;
 
-  function materialDesignHamburger() {
+  function materialDesignHamburger(el) {
     'use strict';
 
-    document.querySelector('.material-design-hamburger__icon').addEventListener(
-        'click',
-        function() {
+    el.addEventListener('click', function() {
       var child = this.childNodes[1].classList;
 
       if (child.contains('material-design-hamburger__icon--to-arrow')) {

--- a/examples/basic-example/index.html
+++ b/examples/basic-example/index.html
@@ -12,5 +12,8 @@
     </section>
 
     <script src="../../dist/material-design-hamburger.js"></script>
+    <script>
+      hamburger(el);
+    </script>
   </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,9 @@
 
 Android's Material Design hamburger animation built in CSS (with a sprinkle of JS).
 
-![Material Design Hamburger](https://i.imgur.com/B0PT1Lb.gif)
+### Example
 
-### Example Usage
-
-See [this pen](http://codepen.io/swirlycheetah/pen/cFtzb) for a styled example.
+See [this pen][1] for a styled example.
 
 ### Browser Support
 
@@ -14,79 +12,52 @@ Currently supporting the 2 latest versions of each major browser (IE10+) with th
 
 ### Installation & Usage
 
-#### Download
+#### NPM
 
-__Download the [latest release](https://github.com/swirlycheetah/material-design-hamburger/releases/latest).__
-
-__Include the CSS & JS files from the `dist` folder where desired within your project.__
-
-__Add the following HTML elements.__
-
-```html
-<section class="material-design-hamburger">
-  <button class="material-design-hamburger__icon">
-    <span class="material-design-hamburger__layer">
-    </span>
-  </button>
-</section>
-```
-
-#### npm
-
-__Install the package (use --save or --save-dev if required).__
+__Install the package (use --save or --save-dev if required)__
 
 `npm install material-design-hamburger`
 
-__Include the CSS & JS where required.__
+__Include the CSS & JS where required__
 
-```html
-<link rel="stylesheet" href="./node_modules/material-design-hamburger/dist/material-design-hamburger.css">
-```
+`<link rel="stylesheet" href="./node_modules/material-design-hamburger/dist/material-design-hamburger.css">`
 
-```html
-<script src="./node_modules/material-design-hamburger/dist/material-design-hamburger.js"></script>
-```
+`<script src="./node_modules/material-design-hamburger/dist/material-design-hamburger.js"></script>`
 
-__Add the following HTML elements.__
+__Add the following HTML elements__
 
-```html
-<section class="material-design-hamburger">
-  <button class="material-design-hamburger__icon">
-  	<span class="material-design-hamburger__layer">
-  	</span>
-  </button>
-</section>
+	    <section class="material-design-hamburger">
+	      <button class="material-design-hamburger__icon">
+	        <span class="material-design-hamburger__layer"></span>
+	      </button>
+	    </section>
+
+```js
+var hamburger = require('material-design-hamburger');
+var el = document.querySelector('.material-design-hamburger__icon');
+
+hamburger(el);
 ```
 
 #### Bower
 
-__Install the package (use --save or --save-dev if required).__
+__Install the package (use --save or --save-dev if required)__
 
 `bower install material-design-hamburger --save-dev`
 
-__Include the CSS & JS where required.__
+__Include the CSS & JS where required__
 
-```html
-<link rel="stylesheet" href="./bower_components/material-design-hamburger/dist/material-design-hamburger.css">
-```
-```html
-<script src="./bower_components/material-design-hamburger/dist/material-design-hamburger.js"></script>
-```
+`<link rel="stylesheet" href="./bower_components/material-design-hamburger/dist/material-design-hamburger.css">`
 
-__Add the following HTML elements.__
+`<script src="./bower_components/material-design-hamburger/dist/material-design-hamburger.js"></script>`
 
-```html
-<section class="material-design-hamburger">
-  <button class="material-design-hamburger__icon">
-  	<span class="material-design-hamburger__layer">
-  	</span>
-  </button>
-</section>
-```
-    
-### In The Wild
+__Add the following HTML elements__
 
-* [APK Mirror](http://www.apkmirror.com/) (only at viewport widths smaller than 993px)
+	    <section class="material-design-hamburger">
+	      <button class="material-design-hamburger__icon">
+	        <span class="material-design-hamburger__layer"></span>
+	      </button>
+	    </section>
 
 ### Roadmap
 
@@ -97,4 +68,7 @@ __Add the following HTML elements.__
 
 ### License
 
-Released under the MIT license: [opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)
+Released under the MIT license: [opensource.org/licenses/MIT][2]
+
+  [1]: http://codepen.io/swirlycheetah/pen/cFtzb
+  [2]: http://opensource.org/licenses/MIT

--- a/src/material-design-hamburger.js
+++ b/src/material-design-hamburger.js
@@ -2,12 +2,10 @@
 
   module.exports = materialDesignHamburger;
 
-  function materialDesignHamburger() {
+  function materialDesignHamburger(el) {
     'use strict';
 
-    document.querySelector('.material-design-hamburger__icon').addEventListener(
-        'click',
-        function() {
+    el.addEventListener('click', function() {
       var child = this.childNodes[1].classList;
 
       if (child.contains('material-design-hamburger__icon--to-arrow')) {


### PR DESCRIPTION
Note: This is a breaking API change which will require a major version bump if merged in.

Favor passing in an `Element` instance over a hard-coded `document.querySelector` to allow for multiple hamburger icons and for better testability.
